### PR TITLE
fix prepublish script

### DIFF
--- a/.changeset/tricky-comics-own.md
+++ b/.changeset/tricky-comics-own.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.graph-maker': patch
+---
+
+fix prepublish script

--- a/block/package.json
+++ b/block/package.json
@@ -5,7 +5,7 @@
     "pretty": "prettier --write \"./**/*.{js,jsx,mjs,cjs,ts,tsx,json,vue}\"",
     "build": "rm -rf ./block-pack && block-tools pack",
     "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'"
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science"
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the block publication lifecycle and records a patch release.
- `prepublishOnly`: npm lifecycle script executed before package publication; changed to invoke `block-tools publish` directly, supply the public registry serve URL, and omit the preceding explicit pack command.
- `registry-serve-url`: public URL associated with the published block registry; newly set to `https://blocks.pl-open.science`.
- `changeset`: release metadata used to determine package versioning and changelog content; adds a patch entry for `@platforma-open/milaboratories.graph-maker`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed files.

The changes consistently update the publication command and add matching patch-release metadata, and the available repository evidence does not establish a reachable publication failure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| block/package.json | Revises the prepublish command to publish directly with an explicit registry serve URL; no concrete changed-code failure was established. |
| .changeset/tricky-comics-own.md | Adds the expected patch changeset documenting the prepublish-script fix. |

</details>

<sub>Reviews (1): Last reviewed commit: ["add changeset"](https://github.com/platforma-open/graph-maker/commit/2f09d7cf4323d7589b77bba42e5336d47946d206) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48703292)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->